### PR TITLE
exif/actions.c: Return empty string on NULL pointer or zero-length string

### DIFF
--- a/exif/actions.c
+++ b/exif/actions.c
@@ -666,7 +666,7 @@ escape_xml(const char *text)
 	char *out;
 	size_t len;
 
-	if (!strlen(text)) return "";
+	if (!text || !*text) return "";
 
 	for (out=escaped, len=0; *text; ++len, ++out, ++text) {
 		/* Make sure there's plenty of room for a quoted character */


### PR DESCRIPTION
Updates and optimizes existing fix for CVE-2021-27815.

