### PR TITLE
exif.1: Add missing .UE macro to render the hyperlink

### DIFF
--- a/exif.1
+++ b/exif.1
@@ -235,3 +235,4 @@ Dan Fandrich and others.
 .SH "SEE ALSO"
 .UR "https://libexif.github.io/"
 .BR "https://libexif.github.io/"
+.UE


### PR DESCRIPTION
Rendering of the "See Also" section of the man-page is broken without the closing .UE macro.